### PR TITLE
Update packetrusher.yaml

### DIFF
--- a/configs/packetrusher.yaml
+++ b/configs/packetrusher.yaml
@@ -38,7 +38,7 @@ ue:
     nea2: true
     nea3: false
 amfif:
-  ip: amf.open5gs.org
-  port: 38412
+  - ip: amf.open5gs.org
+    port: 38412
 logs:
   level: 4


### PR DESCRIPTION
Format of PacketRusher's configuration has been modified in a non backward-compatible way to support multiples AMF (and load balance traffic to multiple AMF using TNL associations).

Sorry for the inconvenience, and thanks for using PacketRusher! :-)